### PR TITLE
Update variables_proxmox_almalinux89.pkvars.hcl

### DIFF
--- a/proxmox/variables_proxmox_almalinux89.pkvars.hcl
+++ b/proxmox/variables_proxmox_almalinux89.pkvars.hcl
@@ -1,4 +1,4 @@
-ansible_extra_args        = ["-e", "@extra/playbooks/provision_alma8_variables.yml", "-e", "@variables/almalinux8.yml"]
+ansible_extra_args        = ["-e", "@extra/playbooks/provision_alma8_variables.yml", "-e", "@variables/almalinux8.yml", "--scp-extra-args", "'-O'" ]
 ansible_verbosity         = ["-v"]
 ballooning_minimum        = "0"
 boot_command              = "<tab> text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux/8/proxmox/ks.cfg<enter><wait10>esc<wait60><esc>"


### PR DESCRIPTION
added scp option for legacy scp transfer to address issue with missing (wrong path) sftp server